### PR TITLE
Added support for optional heater and up to 4 temperature sensors

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -10,6 +10,7 @@ export enum EntityKey {
     charging ='charging',
     discharging ='discharging',
     balancer ='balancer',
+    heater ='heater',
     total_voltage ='total_voltage',
     total_battery_capacity_setting ='total_battery_capacity_setting',
     total_charging_cycle_capacity ='total_charging_cycle_capacity',
@@ -89,4 +90,9 @@ export enum EntityKey {
     cell_resistance_30 ='cell_resistance_30',
     cell_resistance_31 ='cell_resistance_31',
     cell_resistance_32 ='cell_resistance_32',
+
+    temperature_sensor_1 ='temperature_sensor_1',
+    temperature_sensor_2 ='temperature_sensor_2',
+    temperature_sensor_3 ='temperature_sensor_3',
+    temperature_sensor_4 ='temperature_sensor_4',
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -72,6 +72,35 @@ export class JkBmsCardEditor extends LitElement implements LovelaceCardEditor {
                         ],
                     },
                     {
+                        type: 'grid',
+                        title: localize('config.tempSensorsCount'),
+                        schema: [
+                            {
+                                type: 'grid',
+                                schema: [
+                                    {name: 'tempSensorsCount', selector: {number: {min: 0, max: 4, step: 2}}},
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'grid',
+                        title: localize('config.hasHeater'),
+                        schema: [
+                            {
+                                type: 'grid',
+                                schema: [
+                                    {name: 'hasHeater', selector: {
+                                        select: { multiple: false, mode: "list", options: [
+                                          {label: "Yes", value: "1"},
+                                          {label: "No", value: "0"}
+                                        ]}
+                                    }},
+                                ],
+                            },
+                        ],
+                    },
+                    {
                         type: 'expandable',
                         title: localize('config.manualAssignment'),
                         schema: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export class JkBmsCard extends LitElement{
             cellCount: 16,
             cellColumns: 2,
             cellLayout: "bankMode",
+            tempSensorsCount: 0,
+            hasHeater: 0,
             entities: Object.keys(EntityKey).reduce((acc, key) => {
                 acc[key as EntityKey] = '';
                 return acc;
@@ -254,10 +256,11 @@ export class JkBmsCard extends LitElement{
           </div>
         </div>
 
-        <div class="grid grid-3">
+        <div class="grid grid-${this._config.hasHeater=='1'?'4':'3'}">
           ${this._renderSwitch(EntityKey.charging, 'charge')}
           ${this._renderSwitch(EntityKey.discharging, 'discharge')}
           ${this._renderSwitch(EntityKey.balancer, 'balance')}
+          ${this._config.hasHeater == '1' ? this._renderSwitch(EntityKey.heater, 'heater') : ''}
         </div>
           
           ${this._renderError()}
@@ -274,6 +277,7 @@ export class JkBmsCard extends LitElement{
               ${localize('stats.balanceCurrent')} <span class="${balanceClass}">
               ${balanceCurrent.toFixed(1)} A
             </span>
+              ${this._renderTemps(1)}
           </div>
 
           <div class="stats-padding stats-border">
@@ -285,6 +289,7 @@ export class JkBmsCard extends LitElement{
               ${localize('stats.cycles')} <span class="clickable" @click=${(e) => this._navigate(e, EntityKey.charging_cycles)}>${this.getState(EntityKey.charging_cycles)}</span><br>
               ${localize('stats.delta')} <span class="${deltaClass}" @click=${(e) => this._navigate(e, EntityKey.delta_cell_voltage)}> ${this.maxDeltaV.toFixed(3)} V </span><br>
               ${localize('stats.mosfetTemp')} <span class="clickable" @click=${(e) => this._navigate(e, EntityKey.power_tube_temperature)}>${this.getState(EntityKey.power_tube_temperature)} °C</span>
+              ${this._renderTemps(2)}
           </div>
         </div>
 
@@ -320,6 +325,16 @@ export class JkBmsCard extends LitElement{
         return html`<span class="error-message">${state}</span>`
     }
 
+    private _renderTemps(placement): TemplateResult {
+        const sensors: TemplateResult[] = [];
+        const sensorsCount = this._config?.tempSensorsCount ?? 0;
+        for (let i = placement; i <= sensorsCount; i += 2 ) {
+            sensors.push(html`
+                <br>${localize('stats.temperature_sensor_' + i)} <span class="clickable" @click=${(e) => this._navigate(e, EntityKey['temperature_sensor_' + i])}>${this.getState(EntityKey['temperature_sensor_' + i])} °C</span>`);
+        }
+
+        return html`${sensors}`;
+    }
     private _renderCells(bankmode = true): TemplateResult {
         const cells: TemplateResult[] = [];
 

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -10,12 +10,15 @@
     "cellCount": "Number of cells",
     "cellColumns": "Number of columns",
     "cellLayout": "Cell Layout",
-    "manualAssignment": "Manual entity assignment"
+    "manualAssignment": "Manual entity assignment",
+    "tempSensorsCount": "Number of temperature sensors available",
+    "hasHeater": "Heater option is used"
   },
   "switches": {
     "charge": "Charge",
     "discharge": "Discharge",
-    "balance": "Balance"
+    "balance": "Balance",
+    "heater": "Heater"
   },
   "stats": {
     "power": "Power:",
@@ -27,6 +30,10 @@
     "remainingAmps": "Remaining:",
     "cycles": "Cycles:",
     "delta": "Delta V:",
-    "mosfetTemp": "MOS Temp:"
+    "mosfetTemp": "MOS Temp:",
+    "temperature_sensor_1": "Temp. 1:",
+    "temperature_sensor_2": "Temp. 2:",
+    "temperature_sensor_3": "Temp. 3:",
+    "temperature_sensor_4": "Temp. 4:"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
<!--- Describe your changes in detail. -->
<!--- If the change is breaking, it must be detailed what breaks and what users need to do to fix it -->
Added optional control to switch JK BMS heater
Added optional support for up to four temperature sensors
Added settings to adjust temp sensors count ( 0 - disabled )
Added settings to show/hide optional heater


## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. e.g. fixes #123 closes #123 -->
fixes [#12](https://github.com/Pho3niX90/jk-bms-card/issues/12)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->
Some models of JK BMS are supporting external heater to keep battery warm enough to charge it. So it's better to control this feature and monitor temperature via availabel sensors.

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->
Tested on two BMSes with and without heaters and with 2/4 temperature sensors

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My changes generate no new warnings


